### PR TITLE
Fix highlight on modern nxml-mode

### DIFF
--- a/hl-tags-mode.el
+++ b/hl-tags-mode.el
@@ -83,15 +83,21 @@
           (setq end2 (point))
 
           (nxml-backward-single-balanced-item)
-          (setq start2 (point))
-
-          (nxml-up-element -1)
-          (setq end1 (point))
-
-          (nxml-forward-single-balanced-item)
           (setq start1 (point))
 
+          (nxml-down-element 1)
+          (setq end1 (point))
+
+          (hl-tags--jump-to-end-of-current-context)
+          (setq start2 (point))
+
           (cons (cons start1 end1) (cons start2 end2))))
+    (error nil)))
+
+(defun hl-tags--jump-to-end-of-current-context ()
+  (condition-case nil
+      (while t
+        (nxml-forward-balanced-item))
     (error nil)))
 
 (defun hl-tags-context ()


### PR DESCRIPTION
On Emacs 27.2 I get the following results when enabling `hl-tags-mode` in an `nxml-mode` buffer containing

```xml
<?xml version="1.0" encoding="UTF-8"?>
<note>
  <to>Tove</to>
  <from>Jani</from>
  <heading>Reminder</heading>
  <body>Don't forget me this weekend!</body>
</note>
```

Results (before this PR):

<img width="746" alt="Screen Shot 2021-10-08 at 11 49 55" src="https://user-images.githubusercontent.com/2172537/136490619-974b15e4-cdae-4686-9ab9-f77d53f98f26.png">

This doesn't seem right to me. It looks like the behavior of some of the nxml movement functions might have changed. This PR adjusts things to obtain the following results:

<img width="746" alt="Screen Shot 2021-10-08 at 11 42 09" src="https://user-images.githubusercontent.com/2172537/136490496-e935c935-94d8-4178-b77d-48394ce2941c.png">

Potential issues with this change:

- It could produce bad results with whatever Emacs/nxml version this package was originally designed for
- `hl-tags--jump-to-end-of-current-context` is not efficient; I couldn't figure out a better way to jump to the start of the current context's closing tag, so if anyone has a better solution please let me know